### PR TITLE
Show friendly program names in UI

### DIFF
--- a/ActivityTracker.Models/LogEntry.cs
+++ b/ActivityTracker.Models/LogEntry.cs
@@ -4,12 +4,22 @@ using System.Runtime.CompilerServices;
 
 namespace ActivityTracker.Models
 {
-    public class TaskSwitch : INotifyPropertyChanged
+    public class LogEntry : INotifyPropertyChanged
     {
         private long _endTicks;
+        private string _displayName;
 
         public int ProcessId { get; }
         public string ApplicationName { get; }
+        public string DisplayName
+        {
+            get => _displayName;
+            private set
+            {
+                _displayName = value;
+                OnPropertyChanged();
+            }
+        }
         public string WindowTitle { get; }
         public long StartTicks { get; }
         public long EndTicks
@@ -27,16 +37,17 @@ namespace ActivityTracker.Models
 
         public event PropertyChangedEventHandler PropertyChanged;
 
-        public TaskSwitch(int processId, string applicationName, string windowTitle)
+        public LogEntry(int processId, string processName, string windowTitle, string displayName = "")
         {
             ProcessId = processId;
-            ApplicationName = applicationName;
+            ApplicationName = processName;
             WindowTitle = windowTitle;
+            DisplayName = string.IsNullOrWhiteSpace(displayName) ? processName : displayName;
 
             StartTicks = DateTime.UtcNow.Ticks;
         }
 
-        public void EndTaskFocus()
+        public void EndProgramFocus()
         {
             if(EndTicks == 0)
             {

--- a/ActivityTracker.Models/Program.cs
+++ b/ActivityTracker.Models/Program.cs
@@ -5,5 +5,12 @@
         public string ProcessName { get; set; }
         public string DisplayName { get; set; }
         public bool ShouldLog { get; set; }
+
+        public Program(string processName, string displayName, bool shouldLog = true)
+        {
+            ProcessName = processName;
+            DisplayName = displayName;
+            ShouldLog = shouldLog;
+        }
     }
 }

--- a/ActivityTracker.Repository/ActivityTracker.Repository.csproj
+++ b/ActivityTracker.Repository/ActivityTracker.Repository.csproj
@@ -5,9 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ActivityTracker.Engine\ActivityTracker.Engine.csproj" />
     <ProjectReference Include="..\ActivityTracker.Models\ActivityTracker.Models.csproj" />
-    <ProjectReference Include="..\ActivityTracker.Repository\ActivityTracker.Repository.csproj" />
   </ItemGroup>
 
 </Project>

--- a/ActivityTracker.Repository/DataRepository.cs
+++ b/ActivityTracker.Repository/DataRepository.cs
@@ -1,0 +1,39 @@
+﻿using ActivityTracker.Models;
+using System.Collections.ObjectModel;
+
+namespace ActivityTracker.Repository
+{
+    public class DataRepository
+    {
+        private static readonly DataRepository s_dataRepository = 
+            new DataRepository();
+
+        public ObservableCollection<Program> Programs { get; } =
+            new ObservableCollection<Program>();
+
+        private DataRepository()
+        {
+            LoadPrograms();
+        }
+
+        public static DataRepository GetInstance()
+        {
+            return s_dataRepository;
+        }
+
+        // Temporarily hard-coded population, until persistent storage technique is decided
+        private void LoadPrograms()
+        {
+            Programs.Clear();
+
+            // Common programs (these will be added by default, for all installations)
+            Programs.Add(new Program("explorer", "File Explorer"));
+            Programs.Add(new Program("powershell", "PowerShell"));
+            Programs.Add(new Program("firefox", "Firefox"));
+
+            // Uncommon programs that I personally use (these would be manually added by the user)
+            Programs.Add(new Program("devenv", "Visual Studio"));
+            Programs.Add(new Program("PngGauntlet", "PNGGauntlet"));
+        }
+    }
+}

--- a/ActivityTracker.sln
+++ b/ActivityTracker.sln
@@ -3,13 +3,15 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.31702.278
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ActivityTracker", "ActivityTracker\ActivityTracker.csproj", "{8FEC2245-5E92-4ED5-90AD-BB7F04697589}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ActivityTracker", "ActivityTracker\ActivityTracker.csproj", "{8FEC2245-5E92-4ED5-90AD-BB7F04697589}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ActivityTracker.Engine", "ActivityTracker.Engine\ActivityTracker.Engine.csproj", "{BF5D402C-96EA-4C61-83AE-8AF088B5186D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ActivityTracker.Engine", "ActivityTracker.Engine\ActivityTracker.Engine.csproj", "{BF5D402C-96EA-4C61-83AE-8AF088B5186D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ActivityTracker.Models", "ActivityTracker.Models\ActivityTracker.Models.csproj", "{C36A258B-60AB-4CCB-A130-0274C1FCB103}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ActivityTracker.Models", "ActivityTracker.Models\ActivityTracker.Models.csproj", "{C36A258B-60AB-4CCB-A130-0274C1FCB103}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ActivityTracker.ViewModels", "ActivityTracker.ViewModels\ActivityTracker.ViewModels.csproj", "{7EB4ECBB-F0C9-499E-998B-D8F21DA36CB4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ActivityTracker.ViewModels", "ActivityTracker.ViewModels\ActivityTracker.ViewModels.csproj", "{7EB4ECBB-F0C9-499E-998B-D8F21DA36CB4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ActivityTracker.Repository", "ActivityTracker.Repository\ActivityTracker.Repository.csproj", "{92E114CA-E387-43F1-80F9-893E4A80619D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,6 +35,10 @@ Global
 		{7EB4ECBB-F0C9-499E-998B-D8F21DA36CB4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7EB4ECBB-F0C9-499E-998B-D8F21DA36CB4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7EB4ECBB-F0C9-499E-998B-D8F21DA36CB4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{92E114CA-E387-43F1-80F9-893E4A80619D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{92E114CA-E387-43F1-80F9-893E4A80619D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{92E114CA-E387-43F1-80F9-893E4A80619D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{92E114CA-E387-43F1-80F9-893E4A80619D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ActivityTracker/MainWindow.xaml
+++ b/ActivityTracker/MainWindow.xaml
@@ -44,7 +44,7 @@
         
         <DataGrid Grid.Row="1" Grid.Column="0"
                   Margin="5,5,5,5"
-                  ItemsSource="{Binding TaskSwitchLogEntries}"
+                  ItemsSource="{Binding LogEntries}"
                   AutoGenerateColumns="False"
                   IsReadOnly="True"
                   CanUserAddRows="False"
@@ -58,7 +58,7 @@
             <DataGrid.Columns>
                 <DataGridTextColumn Header="Program Name"
                                     Width="Auto"
-                                    Binding="{Binding ApplicationName, Mode=OneWay}"/>
+                                    Binding="{Binding DisplayName, Mode=OneWay}"/>
                 <DataGridTextColumn Header="Window Title"
                                     Width="*"
                                     Binding="{Binding WindowTitle, Mode=OneWay}"/>

--- a/ActivityTracker/MainWindow.xaml.cs
+++ b/ActivityTracker/MainWindow.xaml.cs
@@ -29,7 +29,7 @@ namespace ActivityTracker
         {
             Application.Current?.Dispatcher?.Invoke(() =>
             {
-                (DataContext as TaskSwitchLog).EndCurrentTask();
+                (DataContext as TaskSwitchLog).EndCurrentProgramFocus();
             });
 
             // TODO: Add entries to "database"


### PR DESCRIPTION
Added ability to set/display DisplayName for focused programs, instead of using non-friendly Process.ProcessName.

Renamed some classes from "Task" to "Log", since we aren't really tracking 'tasks'.